### PR TITLE
Port to gst 1.0

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,7 +1,7 @@
 Installation Instructions
 *************************
 
-Copyright (C) 1994-1996, 1999-2002, 2004-2011 Free Software Foundation,
+Copyright (C) 1994-1996, 1999-2002, 2004-2013 Free Software Foundation,
 Inc.
 
    Copying and distribution of this file, with or without modification,
@@ -12,8 +12,8 @@ without warranty of any kind.
 Basic Installation
 ==================
 
-   Briefly, the shell commands `./configure; make; make install' should
-configure, build, and install this package.  The following
+   Briefly, the shell command `./configure && make && make install'
+should configure, build, and install this package.  The following
 more-detailed instructions are generic; see the `README' file for
 instructions specific to this package.  Some packages provide this
 `INSTALL' file but do not implement all of the features documented
@@ -309,9 +309,10 @@ causes the specified `gcc' to be used as the C compiler (unless it is
 overridden in the site shell script).
 
 Unfortunately, this technique does not work for `CONFIG_SHELL' due to
-an Autoconf bug.  Until the bug is fixed you can use this workaround:
+an Autoconf limitation.  Until the limitation is lifted, you can use
+this workaround:
 
-     CONFIG_SHELL=/bin/bash /bin/bash ./configure CONFIG_SHELL=/bin/bash
+     CONFIG_SHELL=/bin/bash ./configure CONFIG_SHELL=/bin/bash
 
 `configure' Invocation
 ======================
@@ -367,4 +368,3 @@ operates.
 
 `configure' also accepts some other, not widely useful, options.  Run
 `configure --help' for more details.
-

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl required version of autoconf
 AC_PREREQ([2.53])
 
-AC_INIT([libgstspotify],[0.2.0])
+AC_INIT([libgstspotify],[1.0.0])
 
 dnl required versions of gstreamer and plugins-base
 GST_REQUIRED=1.0.0

--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,7 @@ PKG_CHECK_MODULES(GST, [
 dnl check if compiler understands -Wall (if yes, add -Wall to GST_CFLAGS)
 AC_MSG_CHECKING([to see if compiler understands -Wall])
 save_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS -Wall"
+CFLAGS="$CFLAGS -Wall -DGST_DISABLE_DEPRECATED"
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([ ], [ ])], [
   GST_CFLAGS="$GST_CFLAGS -Wall"
   AC_MSG_RESULT([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,11 @@
 dnl required version of autoconf
 AC_PREREQ([2.53])
 
-AC_INIT([libgstspotify],[0.1.0])
+AC_INIT([libgstspotify],[0.2.0])
 
 dnl required versions of gstreamer and plugins-base
-GST_REQUIRED=0.10.16
-GSTPB_REQUIRED=0.10.16
+GST_REQUIRED=1.0.0
+GSTPB_REQUIRED=1.0.0
 
 AC_CONFIG_SRCDIR([src/gstspotify.c])
 AC_CONFIG_HEADERS([config.h])
@@ -42,9 +42,9 @@ dnl for libgstrtp-0.10: gstreamer-rtp-0.10 >= $GST_REQUIRED
 dnl for libgstrtsp-0.10: gstreamer-rtsp-0.10 >= $GST_REQUIRED
 dnl etc.
 PKG_CHECK_MODULES(GST, [
-  gstreamer-0.10 >= $GST_REQUIRED
-  gstreamer-base-0.10 >= $GST_REQUIRED
-  gstreamer-controller-0.10 >= $GST_REQUIRED
+  gstreamer-1.0 >= $GST_REQUIRED
+  gstreamer-base-1.0 >= $GST_REQUIRED
+  gstreamer-controller-1.0 >= $GST_REQUIRED
 ], [
   AC_SUBST(GST_CFLAGS)
   AC_SUBST(GST_LIBS)
@@ -52,8 +52,8 @@ PKG_CHECK_MODULES(GST, [
   AC_MSG_ERROR([
       You need to install or upgrade the GStreamer development
       packages on your system. On debian-based systems these are
-      libgstreamer0.10-dev and libgstreamer-plugins-base0.10-dev.
-      on RPM-based systems gstreamer0.10-devel, libgstreamer0.10-devel
+      libgstreamer1.0-dev and libgstreamer-plugins-base1.0-dev.
+      on RPM-based systems gstreamer1.0-devel, libgstreamer1.0-devel
       or similar. The minimum version required is $GST_REQUIRED.
   ])
 ])
@@ -71,9 +71,12 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([ ], [ ])], [
 
 dnl set the plugindir where plugins should be installed (for src/Makefile.am)
 if test "x${prefix}" = "x$HOME"; then
-  plugindir="$HOME/.gstreamer-0.10/plugins"
+  plugindir="$HOME/.gstreamer-1.0/plugins"
 else
-  plugindir="\$(libdir)/gstreamer-0.10"
+dnl  plugindir="\$(libdir)/gstreamer-1.0"
+dnl  Fix appreciated, the path above resolves to /usr/local/lib/gstreamer-1.0
+dnl  where GStreamer 1.0 doesn't pick it up! Temporarily hardcoded arch:
+  plugindir="/usr/lib/x86_64-linux-gnu/gstreamer-1.0"
 fi
 AC_SUBST(plugindir)
 
@@ -83,4 +86,3 @@ AC_SUBST(GST_PLUGIN_LDFLAGS)
 
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT
-

--- a/src/gstspotify.c
+++ b/src/gstspotify.c
@@ -42,6 +42,6 @@ plugin_init (GstPlugin * plugin)
 GST_PLUGIN_DEFINE (
     GST_VERSION_MAJOR,
     GST_VERSION_MINOR,
-    "spotify",
+    spotify,
     "Element used to provide audio music hosted by spotify",
     plugin_init, VERSION, "LGPL", "GStreamer", "http://gstreamer.net/")

--- a/src/gstspotify.c
+++ b/src/gstspotify.c
@@ -39,7 +39,8 @@ plugin_init (GstPlugin * plugin)
   return TRUE;
 }
 
-GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
+GST_PLUGIN_DEFINE (
+    GST_VERSION_MAJOR,
     GST_VERSION_MINOR,
     "spotify",
     "Element used to provide audio music hosted by spotify",

--- a/src/gstspotifysrc.c
+++ b/src/gstspotifysrc.c
@@ -1,4 +1,4 @@
-/* GStreamer
+/*
  * Copyright (C) 2007 David Schleef <ds@schleef.org>
  *           (C) 2008 Wim Taymans <wim.taymans@gmail.com>
  *           (C) 2015 Canonical <michal.karnicki@canonical.com>
@@ -17,12 +17,6 @@
  * License along with this library; if not, write to the
  * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
  * Boston, MA 02111-1307, USA.
- */
-/**
- * SECTION:gstspotifysrc
- * @short_description: Easy way for applications to inject spotify music
- *   into a pipeline
- * @see_also: #GstBaseSrc
  */
 
 #ifdef HAVE_CONFIG_H
@@ -156,41 +150,16 @@ static gboolean spotify_seek(GstSpotifySessionContext *context, int offset);
 static gboolean spotify_play(GstSpotifySessionContext *context, const char *link);
 static gboolean spotify_stop(GstSpotifySessionContext *context);
 
-static void
-_do_init (GType filesrc_type)
-{
-  static const GInterfaceInfo urihandler_info = {
-    gst_spotify_src_uri_handler_init,
-    NULL,
-    NULL
-  };
-  g_type_add_interface_static (filesrc_type, GST_TYPE_URI_HANDLER,
-      &urihandler_info);
-}
-
-GST_BOILERPLATE_FULL (GstSpotifySrc, gst_spotify_src, GstBaseSrc, GST_TYPE_BASE_SRC,
-    _do_init);
-
-static void
-gst_spotify_src_base_init (gpointer g_class)
-{
-  GstElementClass *element_class = GST_ELEMENT_CLASS (g_class);
-
-  GST_DEBUG_CATEGORY_INIT (spotify_src_debug, "spotify", 0, "spotifysrc element");
-
-  gst_element_class_set_details_simple (element_class, "SpotifySrc",
-      "Generic/Source", "Feed spotify hosted music to a pipeline",
-      "Liam Wickins <liamw9534@gmail.com");
-
-  gst_element_class_add_pad_template (element_class,
-      gst_static_pad_template_get (&gst_spotify_src_template));
-}
+#define parent_class gst_spotify_src_parent_class
+G_DEFINE_TYPE_EXTENDED (GstSpotifySrc, gst_spotify_src, GST_TYPE_BASE_SRC, 0,
+    G_IMPLEMENT_INTERFACE(GST_TYPE_URI_HANDLER, gst_spotify_src_uri_handler_init));
 
 static void
 gst_spotify_src_class_init (GstSpotifySrcClass * klass)
 {
   GObjectClass *gobject_class = (GObjectClass *) klass;
   GstBaseSrcClass *basesrc_class = (GstBaseSrcClass *) klass;
+  GstElementClass *element_class = (GstElementClass *) klass;
 
   gobject_class->dispose = gst_spotify_src_dispose;
   gobject_class->finalize = gst_spotify_src_finalize;
@@ -225,16 +194,27 @@ gst_spotify_src_class_init (GstSpotifySrcClass * klass)
   basesrc_class->get_size = gst_spotify_src_do_get_size;
   basesrc_class->query = gst_spotify_src_query;
 
+  gst_element_class_add_pad_template (element_class,
+    gst_static_pad_template_get (&gst_spotify_src_template));
+
+  gst_element_class_set_details_simple (element_class, "Spotify audio source",
+    "Generic/Source",
+    "Feed spotify hosted music to a pipeline",
+    "Liam Wickins <liamw9534@gmail.com>");
+
+  GST_DEBUG_CATEGORY_INIT (
+    spotify_src_debug, "spotify", 0, "spotifysrc element");
+
   g_type_class_add_private (klass, sizeof (GstSpotifySrcPrivate));
 }
 
 static void
-gst_spotify_src_init (GstSpotifySrc * spotifysrc, GstSpotifySrcClass * klass)
+gst_spotify_src_init (GstSpotifySrc * spotifysrc)
 {
   GstSpotifySrcPrivate *priv;
 
-  priv = spotifysrc->priv = G_TYPE_INSTANCE_GET_PRIVATE (spotifysrc, GST_TYPE_SPOTIFY_SRC,
-      GstSpotifySrcPrivate);
+  priv = spotifysrc->priv = G_TYPE_INSTANCE_GET_PRIVATE (
+        spotifysrc, GST_TYPE_SPOTIFY_SRC, GstSpotifySrcPrivate);
 
   priv->queue = g_queue_new ();
 
@@ -290,8 +270,6 @@ gst_spotify_src_finalize (GObject * obj)
   g_free (priv->appkey_file);
   g_free (priv->user);
   g_free (priv->pass);
-  g_mutex_clear(&priv->mutex);
-  g_cond_clear(&priv->cond);
   g_queue_free (priv->queue);
 
   G_OBJECT_CLASS (parent_class)->finalize (obj);
@@ -358,11 +336,11 @@ gst_spotify_src_unlock (GstBaseSrc * bsrc)
   GstSpotifySrc *spotifysrc = GST_SPOTIFY_SRC_CAST (bsrc);
   GstSpotifySrcPrivate *priv = spotifysrc->priv;
 
-  g_mutex_init(&priv->mutex);
+  g_mutex_lock(&priv->mutex);
   GST_DEBUG_OBJECT (spotifysrc, "unlock start");
   priv->flushing = TRUE;
   g_cond_broadcast(&priv->cond);
-  g_mutex_clear(&priv->mutex);
+  g_mutex_unlock(&priv->mutex);
 
   return TRUE;
 }
@@ -373,11 +351,11 @@ gst_spotify_src_unlock_stop (GstBaseSrc * bsrc)
   GstSpotifySrc *spotifysrc = GST_SPOTIFY_SRC_CAST (bsrc);
   GstSpotifySrcPrivate *priv = spotifysrc->priv;
 
-  g_mutex_init(&priv->mutex);
+  g_mutex_lock(&priv->mutex);
   GST_DEBUG_OBJECT (spotifysrc, "unlock stop");
   priv->flushing = FALSE;
   g_cond_broadcast(&priv->cond);
-  g_mutex_clear(&priv->mutex);
+  g_mutex_unlock(&priv->mutex);
 
   return TRUE;
 }
@@ -388,7 +366,7 @@ gst_spotify_src_start (GstBaseSrc * bsrc)
   GstSpotifySrc *spotifysrc = GST_SPOTIFY_SRC_CAST (bsrc);
   GstSpotifySrcPrivate *priv = spotifysrc->priv;
 
-  g_mutex_init(&priv->mutex);
+  g_mutex_lock(&priv->mutex);
   GST_DEBUG_OBJECT (spotifysrc, "starting");
   priv->is_first_seek = TRUE;
   priv->flushing = FALSE;
@@ -400,12 +378,12 @@ gst_spotify_src_start (GstBaseSrc * bsrc)
       !spotify_login(priv->spotify_context, priv->user, priv->pass) ||
       !spotify_play(priv->spotify_context, gst_uri_get_location(priv->uri)))
   {
-    g_mutex_clear(&priv->mutex);
+    g_mutex_unlock(&priv->mutex);
     return FALSE;
   }
 
   priv->started = TRUE;
-  g_mutex_clear(&priv->mutex);
+  g_mutex_unlock(&priv->mutex);
 
   gst_base_src_set_format (bsrc, GST_FORMAT_TIME);
 
@@ -418,7 +396,7 @@ gst_spotify_src_stop (GstBaseSrc * bsrc)
   GstSpotifySrc *spotifysrc = GST_SPOTIFY_SRC_CAST (bsrc);
   GstSpotifySrcPrivate *priv = spotifysrc->priv;
 
-  g_mutex_init(&priv->mutex);
+  g_mutex_lock(&priv->mutex);
   GST_DEBUG_OBJECT (spotifysrc, "stopping");
   priv->is_eos = FALSE;
   priv->flushing = TRUE;
@@ -428,7 +406,7 @@ gst_spotify_src_stop (GstBaseSrc * bsrc)
   spotify_destroy(priv->spotify_context);
 
   priv->started = FALSE;
-  g_mutex_clear(&priv->mutex);
+  g_mutex_unlock(&priv->mutex);
 
   return TRUE;
 }
@@ -518,7 +496,7 @@ gst_spotify_src_do_seek (GstBaseSrc * src, GstSegment * segment)
   res = spotify_seek(priv->spotify_context, (desired_position / GST_MSECOND));
 
   if (res) {
-    g_mutex_init(&priv->mutex);
+    g_mutex_lock(&priv->mutex);
     GST_DEBUG_OBJECT (spotifysrc, "flushing queue");
     gst_spotify_src_flush_queued (spotifysrc);
     priv->is_eos = FALSE;
@@ -526,7 +504,7 @@ gst_spotify_src_do_seek (GstBaseSrc * src, GstSegment * segment)
     GST_DEBUG_OBJECT (spotifysrc, "Waiting for seek to arrive...");
     g_cond_wait(&priv->cond, &priv->mutex);
     GST_DEBUG_OBJECT (spotifysrc, "Seek has arrived...");
-    g_mutex_clear(&priv->mutex);
+    g_mutex_unlock(&priv->mutex);
   } else {
     GST_WARNING_OBJECT (spotifysrc, "seek failed");
   }
@@ -560,7 +538,7 @@ gst_spotify_src_create (GstBaseSrc * bsrc, guint64 offset, guint size,
     GST_OBJECT_UNLOCK (spotifysrc);
   }
 
-  g_mutex_init(&priv->mutex);
+  g_mutex_lock(&priv->mutex);
   /* check flushing first */
   if (G_UNLIKELY (priv->flushing))
     goto flushing;
@@ -611,7 +589,7 @@ gst_spotify_src_create (GstBaseSrc * bsrc, guint64 offset, guint size,
     g_cond_wait(&priv->cond, &priv->mutex);
   }
 
-  g_mutex_clear(&priv->mutex);
+  g_mutex_unlock(&priv->mutex);
   if (caps)
     gst_caps_unref (caps);
   return ret;
@@ -620,7 +598,7 @@ gst_spotify_src_create (GstBaseSrc * bsrc, guint64 offset, guint size,
 flushing:
   {
     GST_DEBUG_OBJECT (spotifysrc, "we are flushing");
-    g_mutex_clear(&priv->mutex);
+    g_mutex_unlock(&priv->mutex);
     if (caps)
       gst_caps_unref (caps);
     return GST_FLOW_WRONG_STATE;
@@ -628,7 +606,7 @@ flushing:
 eos:
   {
     GST_DEBUG_OBJECT (spotifysrc, "we are EOS");
-    g_mutex_clear(&priv->mutex);
+    g_mutex_unlock(&priv->mutex);
     if (caps)
       gst_caps_unref (caps);
     return GST_FLOW_UNEXPECTED;
@@ -644,7 +622,7 @@ static guint gst_spotify_src_alloc_and_queue(GstSpotifySrc * spotifysrc,
 
   priv = spotifysrc->priv;
 
-  g_mutex_init(&priv->mutex);
+  g_mutex_lock(&priv->mutex);
 
   /* can't accept buffers when we are flushing or EOS */
   if (priv->flushing)
@@ -657,7 +635,7 @@ static guint gst_spotify_src_alloc_and_queue(GstSpotifySrc * spotifysrc,
     GST_DEBUG_OBJECT (spotifysrc,
         "queue filled (%" G_GUINT64_FORMAT " >= %" G_GUINT64_FORMAT ")",
         priv->queued_bytes, priv->max_bytes);
-    g_mutex_clear(&priv->mutex);
+    g_mutex_unlock(&priv->mutex);
     return 0;
   }
 
@@ -666,7 +644,7 @@ static guint gst_spotify_src_alloc_and_queue(GstSpotifySrc * spotifysrc,
   if (!buffer)
   {
       GST_DEBUG_OBJECT (spotifysrc, "gst_buffer allocation failed");
-      g_mutex_clear(&priv->mutex);
+      g_mutex_unlock(&priv->mutex);
       return 0;
   }
 
@@ -684,7 +662,7 @@ static guint gst_spotify_src_alloc_and_queue(GstSpotifySrc * spotifysrc,
                     priv->queued_bytes, priv->buffer_timestamp);
   priv->buffer_timestamp += duration;
   g_cond_broadcast(&priv->cond);
-  g_mutex_clear(&priv->mutex);
+  g_mutex_unlock(&priv->mutex);
 
   return num_frames;
 
@@ -692,13 +670,13 @@ static guint gst_spotify_src_alloc_and_queue(GstSpotifySrc * spotifysrc,
 flushing:
   {
     GST_DEBUG_OBJECT (spotifysrc, "refuse music data, we are flushing");
-    g_mutex_clear(&priv->mutex);
+    g_mutex_unlock(&priv->mutex);
     return num_frames;
   }
 eos:
   {
     GST_DEBUG_OBJECT (spotifysrc, "refuse music data, we are EOS");
-    g_mutex_clear(&priv->mutex);
+    g_mutex_unlock(&priv->mutex);
     return num_frames;
   }
 }
@@ -709,7 +687,7 @@ static void gst_spotify_src_end_of_stream (GstSpotifySrc * spotifysrc)
 
   priv = spotifysrc->priv;
 
-  g_mutex_init(&priv->mutex);
+  g_mutex_lock(&priv->mutex);
   /* can't accept buffers when we are flushing. We can accept them when we are
    * EOS although it will not do anything. */
   if (priv->flushing)
@@ -718,14 +696,14 @@ static void gst_spotify_src_end_of_stream (GstSpotifySrc * spotifysrc)
   GST_DEBUG_OBJECT (spotifysrc, "sending EOS");
   priv->is_eos = TRUE;
   g_cond_broadcast(&priv->cond);
-  g_mutex_clear(&priv->mutex);
+  g_mutex_unlock(&priv->mutex);
 
   return;
 
   /* ERRORS */
 flushing:
   {
-    g_mutex_clear(&priv->mutex);
+    g_mutex_unlock(&priv->mutex);
     GST_DEBUG_OBJECT (spotifysrc, "refuse EOS, we are flushing");
   }
 }
@@ -828,7 +806,7 @@ gst_spotify_src_uri_handler_init (gpointer g_iface, gpointer iface_data)
 
 static void spotify_main_loop(GstSpotifySessionContext *context)
 {
-  g_mutex_init(&context->mutex);
+  g_mutex_lock(&context->mutex);
   while (!context->destroy) {
     gint64 end_time;
     int timeout;
@@ -842,7 +820,7 @@ static void spotify_main_loop(GstSpotifySessionContext *context)
     end_time = g_get_monotonic_time () + 1 * G_TIME_SPAN_SECOND;
     g_cond_wait_until(&context->cond, &context->mutex, end_time);
   }
-  g_mutex_clear(&context->mutex);
+  g_mutex_unlock(&context->mutex);
 }
 
 static void spotify_loop(void)
@@ -859,7 +837,7 @@ static gboolean spotify_login(GstSpotifySessionContext *context,
 {
   context->logged_in = FALSE;
   GST_DEBUG_OBJECT (g_spotifysrc, "attempting to login");
-  g_mutex_init(&context->mutex);
+  g_mutex_lock(&context->mutex);
   sp_error ret = sp_session_login(context->session, user, password,
                                   FALSE, NULL);
 
@@ -872,27 +850,27 @@ static gboolean spotify_login(GstSpotifySessionContext *context,
 
     if (!context->logged_in)
       goto loginfailed;
-    g_mutex_clear(&context->mutex);
+    g_mutex_unlock(&context->mutex);
     return TRUE;
   }
 
 loginfailed:
   GST_DEBUG_OBJECT (g_spotifysrc, "unable to login - error = %d", ret);
-  g_mutex_clear(&context->mutex);
+  g_mutex_unlock(&context->mutex);
   return FALSE;
 }
 
 static gboolean spotify_seek(GstSpotifySessionContext *context, int offset)
 {
   GST_DEBUG_OBJECT (g_spotifysrc, "attempting to seek - offset = %d", offset);
-  g_mutex_init(&context->mutex);
+  g_mutex_lock(&context->mutex);
   sp_error ret = sp_session_player_seek(context->session, offset);
   if (ret != SP_ERROR_OK) {
     GST_DEBUG_OBJECT (g_spotifysrc, "unable to seek - error = %d", ret);
-    g_mutex_clear(&context->mutex);
+    g_mutex_unlock(&context->mutex);
     return FALSE;
   }
-  g_mutex_clear(&context->mutex);
+  g_mutex_unlock(&context->mutex);
   return TRUE;
 }
 
@@ -900,12 +878,12 @@ static gboolean spotify_play(GstSpotifySessionContext *context, const char *link
 {
   GST_DEBUG_OBJECT (g_spotifysrc, "attempting to load link = %s", link);
 
-  g_mutex_init(&context->mutex);
+  g_mutex_lock(&context->mutex);
   sp_link *spl = sp_link_create_from_string(link);
   if (!spl)
   {
     GST_DEBUG_OBJECT (g_spotifysrc, "could not create link for %s", link);
-    g_mutex_clear(&context->mutex);
+    g_mutex_unlock(&context->mutex);
     return FALSE;
   }
 
@@ -914,7 +892,7 @@ static gboolean spotify_play(GstSpotifySessionContext *context, const char *link
   {
     GST_DEBUG_OBJECT (g_spotifysrc, "could not find track for %s", link);
     sp_link_release(spl);
-    g_mutex_clear(&context->mutex);
+    g_mutex_unlock(&context->mutex);
     return FALSE;
   }
 
@@ -934,7 +912,7 @@ static gboolean spotify_play(GstSpotifySessionContext *context, const char *link
     GST_DEBUG_OBJECT (g_spotifysrc, "track loading timed out");
     sp_track_release(spt);
     sp_link_release(spl);
-    g_mutex_clear(&context->mutex);
+    g_mutex_unlock(&context->mutex);
     return FALSE;
   }
 
@@ -945,7 +923,7 @@ static gboolean spotify_play(GstSpotifySessionContext *context, const char *link
     GST_DEBUG_OBJECT (g_spotifysrc, "player could not load track - error = %d", ret);
     sp_track_release(spt);
     sp_link_release(spl);
-    g_mutex_clear(&context->mutex);
+    g_mutex_unlock(&context->mutex);
     return FALSE;
   }
 
@@ -957,36 +935,36 @@ static gboolean spotify_play(GstSpotifySessionContext *context, const char *link
     GST_DEBUG_OBJECT (g_spotifysrc, "player could not play - error = %d", ret);
     sp_track_release(spt);
     sp_link_release(spl);
-    g_mutex_clear(&context->mutex);
+    g_mutex_unlock(&context->mutex);
     return FALSE;
   }
 
-  g_mutex_clear(&context->mutex);
+  g_mutex_unlock(&context->mutex);
   return TRUE;
 }
 
 static gboolean spotify_stop(GstSpotifySessionContext *context)
 {
   GST_DEBUG_OBJECT (g_spotifysrc, "attempting to stop player");
-  g_mutex_init(&context->mutex);
+  g_mutex_lock(&context->mutex);
   sp_error ret = sp_session_player_play(context->session, FALSE);
   if (ret != SP_ERROR_OK) {
     GST_DEBUG_OBJECT (g_spotifysrc, "unable to stop player - error = %d", ret);
-    g_mutex_clear(&context->mutex);
+    g_mutex_unlock(&context->mutex);
     return FALSE;
   }
 
   ret = sp_session_player_unload(context->session);
   if (ret != SP_ERROR_OK) {
     GST_DEBUG_OBJECT (g_spotifysrc, "unable to unload player - error = %d", ret);
-    g_mutex_clear(&context->mutex);
+    g_mutex_unlock(&context->mutex);
     return FALSE;
   }
 
   /* Reset total track size */
   g_spotifysrc->priv->size = -1;
 
-  g_mutex_clear(&context->mutex);
+  g_mutex_unlock(&context->mutex);
   return TRUE;
 }
 
@@ -1175,8 +1153,6 @@ static gboolean spotify_create(char *appkey_file)
 
 fail:
   g_spotifysrc->priv->spotify_context = NULL;
-  g_mutex_clear(&context->mutex);
-  g_cond_clear(&context->cond);
   g_free(context);
   return FALSE;
 }
@@ -1190,14 +1166,12 @@ static gboolean spotify_destroy(GstSpotifySessionContext *context)
   }
 
   GST_DEBUG_OBJECT (g_spotifysrc, "now destroying spotify session");
-  g_mutex_init(&context->mutex);
+  g_mutex_lock(&context->mutex);
   context->destroy = TRUE;
   g_cond_signal(&context->cond);
-  g_mutex_clear(&context->mutex);
+  g_mutex_unlock(&context->mutex);
   g_thread_join(context->thread);
   sp_error ret = sp_session_release(context->session);
-  g_mutex_clear(&context->mutex);
-  g_cond_clear(&context->cond);
   g_free(context);
   g_spotifysrc->priv->spotify_context = NULL;
   if (ret != SP_ERROR_OK) {


### PR DESCRIPTION
Hey, this is a port of gstspotify to work with GStreamer 1.0
-  plugindir="/usr/lib/x86_64-linux-gnu/gstreamer-1.0"
  is the only line that I don't like myself, but maybe you have a better idea how to avoid hardcoding the path, but using the right one (as in the originally used one GStreamer doesn't pick it up).
